### PR TITLE
Make switch_network.switch raise an error if it fails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
   "flake8",
   "pytest",
   "pytest-cov",
+  "pytest-mock",
 ]
 
 [tool.setuptools.packages.find]

--- a/src/switch_network/__init__.py
+++ b/src/switch_network/__init__.py
@@ -2,9 +2,9 @@ __author__ = "Charlie Tolley"
 __version__ = "0.0.1"
 
 try:
-   from .switch import SwitchNetwork
-   from . import testing
+    from .switch import SwitchNetwork
+    from . import testing
 except ImportError:
-   print("Running on Pico, skipping SwitchNetwork import")
-finally: 
-   from . import pico_utils
+    print("Running on Pico, skipping SwitchNetwork import")
+finally:
+    from . import pico_utils

--- a/src/switch_network/switch.py
+++ b/src/switch_network/switch.py
@@ -54,7 +54,7 @@ class SwitchNetwork:
 
         Raises
         ------
-        ValueError
+        RuntimeError
             If the serial port cannot be opened.
 
         """
@@ -69,13 +69,12 @@ class SwitchNetwork:
         except serial.SerialException as e:
             error_msg = f"Could not open serial port {serport}: {e}"
             self.logger.error(error_msg)
-            raise ValueError(error_msg)
+            raise RuntimeError(error_msg) from e
 
     def switch(self, pathname, verify=True):
         """
-        Set switches at given GPIO pins to the low/high power modes specified
-        by paths. Returns the path that was set, its corresponding pathname,
-        and if it matches the path requested if ``verify'' is True.
+        Set switches at given GPIO pins to the low/high power modes
+        specified by paths.
 
         Parameters
         ----------
@@ -84,15 +83,10 @@ class SwitchNetwork:
         verify : bool
             If True, will verify the switch state after setting it.
 
-        Returns
+        Raises
         -------
-        set_path : str
-            The path that was set. Only returned if ``verify'' is True.
-        set_pathname : str
-            The pathname corresponding to the set path. Only returned if
-            ``verify'' is True.
-        match : bool
-            If ``verify'' is True, returns whether the set path matches the
+        RuntimeError
+            If `verify` is True and the switch state does not match the
             requested path.
 
         """
@@ -107,25 +101,20 @@ class SwitchNetwork:
         time.sleep(0.05)  # wait for switch
         self.logger.info(f"{pathname} is set.")
         if verify:
-            set_path = self._verify_switch()
+            set_path = self.check_switch()
             match = set_path == path[:-1]  # remove the verification character
             if match:
                 self.logger.info(f"Switch verified: {set_path}.")
-                set_pathname = pathname
             else:
-                self.logger.error(f"Switch verification failed: {set_path}.")
-                set_pathname = INV_PATHS.get(set_path, "UNKNOWN")
-            obs_mode = set_pathname
-        else:
-            obs_mode = pathname
+                raise RuntimeError(
+                    f"Switch verification failed: {set_path} != {path[:-1]}."
+                )
         if self.redis is not None:
-            self.redis.add_metadata("obs_mode", obs_mode)
-        if verify:
-            return set_path, set_pathname, match
+            self.redis.add_metadata("obs_mode", pathname)
 
-    def _verify_switch(self):
+    def check_switch(self):
         """
-        Verify the current switch state by reading from the serial port.
+        Check the current switch state by reading from the serial port.
 
         Returns
         -------
@@ -152,7 +141,7 @@ class SwitchNetwork:
         set_path = set_path.strip()
         return set_path
 
-    def powerdown(self, verify=False):
+    def powerdown(self, verify=True):
         """
         Switch to the low power state by setting all GPIOs to low.
 
@@ -161,15 +150,6 @@ class SwitchNetwork:
         verify : bool
             If True, will verify the switch state after setting it.
 
-        Returns
-        -------
-        path : str
-            The path that was set. Only returned if ``verify'' is True.
-
         """
         self.logger.info("Switching to low power mode.")
-        out = self.switch(pathname=LOW_POWER_PATHNAME, verify=verify)
-
-        if verify:
-            path = out[0]
-            return path
+        self.switch(pathname=LOW_POWER_PATHNAME, verify=verify)

--- a/src/switch_network/switch.py
+++ b/src/switch_network/switch.py
@@ -2,16 +2,8 @@ import logging
 import serial
 import time
 
-"""
-The SwitchNetwork class sends commands to the pico connected to the serport.
+logger = logging.getLogger(__name__)
 
-Hard-coded variables:
-
-PATHS dictionary. The keys start with where the path starts: either RF
-(port connected to LNA) or VNA (port connected to the VNA), and end with the
-end of the path - ANT (antenna), O, S, L (OSL standards), or N (noise source).
-
-"""
 PATHS = {
     "VNAO": "10000000",
     "VNAS": "11000000",
@@ -33,7 +25,6 @@ class SwitchNetwork:
         paths=PATHS,
         serport="/dev/ttyACM0",
         timeout=10,
-        logger=None,
         redis=None,
     ):
         """
@@ -47,7 +38,6 @@ class SwitchNetwork:
             Serial port for Pico connection.
         timeout : float
             Timeout for each blocking call to the serial port.
-        logger : logging.Logger
         redis : eigsep_observing.EigsepRedis
             Redis instance to push observing modes to.
 
@@ -57,9 +47,6 @@ class SwitchNetwork:
             If the paths do not have the same number of GPIO pins.
 
         """
-        if logger is None:
-            logger = logging.getLogger(__name__)
-            logger.setLevel(logging.INFO)
         self.logger = logger
         npins = len(next(iter(paths.values())))
         for path in paths.values():

--- a/src/switch_network/switch.py
+++ b/src/switch_network/switch.py
@@ -89,7 +89,7 @@ class SwitchNetwork:
         -------
         ser : serial.Serial
             The serial connection object.
-        
+
         Raises
         ------
         RuntimeError

--- a/src/switch_network/testing.py
+++ b/src/switch_network/testing.py
@@ -46,7 +46,7 @@ class DummySwitchNetwork(SwitchNetwork):
         self.redis = None
         # create a dummy serial connection
         self.ser, self.pico = create_serial_connection(timeout=1)
-        self._fail_switch = False  # simulate a failure in switching
+        self.fail_switch = False  # simulate a failure in switching
         # create dummy setpins
         self.setpins = [DummyPin(gpio) for gpio in range(7)]
 
@@ -57,7 +57,7 @@ class DummySwitchNetwork(SwitchNetwork):
         nread = len(self.setpins) + 2
         command = self.pico.readline(nread).decode().strip()
         if command:
-            if self._fail_switch:  # swap 0 and 1
+            if self.fail_switch:  # swap 0 and 1
                 c1 = command.replace("0", "2")  # swap 0 with 2
                 c2 = c1.replace("1", "0")  # swap 1 with 0
                 command = c2.replace("2", "1")  # swap 2 with 1
@@ -67,24 +67,23 @@ class DummySwitchNetwork(SwitchNetwork):
             if reply:
                 self.pico.write(reply.encode())
 
-    def _verify_switch(self):
+    def check_switch(self):
         """
         Override verify method by mocking a Pico switching and
-        responding. If the attribute _fail_switch is set to True,
+        responding. If the attribute fail_switch is set to True,
         it will simulate a failure in switching.
         """
         # this part is in scripts/main.py and runs on the Pico
         self._do_switch_on_pico()
         # run the verify method
-        return super()._verify_switch()
+        return super().check_switch()
 
-    def powerdown(self, verify=False):
+    def powerdown(self, verify=True):
         """
         Override powerdown method to simulate power down.
         """
-        if verify:  # calls do_switch already
+        if verify:  # calls _do_switch_on_pico under the hood
             return super().powerdown(verify=True)
-        # run the powerdown method
+        # need to call _do_switch_on_pico manually
         super().powerdown(verify=False)
-        # this part is in scripts/main.py and runs on the Pico
         self._do_switch_on_pico()

--- a/src/switch_network/testing.py
+++ b/src/switch_network/testing.py
@@ -1,8 +1,6 @@
-import logging
-
 from mockserial import create_serial_connection
 
-from . import switch, SwitchNetwork, pico_utils
+from . import SwitchNetwork, pico_utils
 
 
 class DummyPin:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,5 +1,7 @@
 import pytest
 
+import serial
+
 import switch_network
 from switch_network import SwitchNetwork
 
@@ -9,55 +11,56 @@ def dummy_switch():
     return switch_network.testing.DummySwitchNetwork()
 
 
-def test_init_failure():
-    with pytest.raises(ValueError):
+def test_init_failure(monkeypatch):
+    def fake_serial(port, baudrate, timeout=None):
+        raise serial.SerialException("Cannot open serial port")
+
+    monkeypatch.setattr(serial, "Serial", fake_serial)
+    with pytest.raises(RuntimeError):
         SwitchNetwork()  # can't open serial port
 
 
-def test_switch(dummy_switch):
+def test_switch(dummy_switch, mocker):
+    # spy on check_switch
+    spy = mocker.spy(SwitchNetwork, "check_switch")
     assert dummy_switch is not None
     # switch paths
     for pathname in dummy_switch.paths:
         path = dummy_switch.paths[pathname]
         dummy_switch.switch(pathname, verify=False)
+        spy.assert_not_called()  # check_switch not called
         nread = len(path) + 2
         read = dummy_switch.pico.readline(nread).strip().decode()
         assert read == path
     # verify switch states
     for pathname in dummy_switch.paths:
         path = dummy_switch.paths[pathname]
-        set_path, set_pathname, match = dummy_switch.switch(
-            pathname, verify=True
-        )
-        assert match is True
-        assert set_path == path
-        assert switch_network.switch.PATHS[set_pathname] == set_path
+        # runs without error
+        dummy_switch.switch(pathname, verify=True)
+    assert spy.call_count == len(dummy_switch.paths)
     # failure in switching
-    dummy_switch._fail_switch = True
+    dummy_switch.fail_switch = True
     for pathname in dummy_switch.paths:
         path = dummy_switch.paths[pathname]
-        set_path, set_pathname, match = dummy_switch.switch(
-            pathname, verify=True
-        )
-        assert match is False
-        assert set_path != path
+        with pytest.raises(RuntimeError):
+            dummy_switch.switch(pathname, verify=True)
 
 
-def test_verify_switch(dummy_switch):
+def test_check_switch(dummy_switch):
     for pathname in dummy_switch.paths:
         path = dummy_switch.paths[pathname]
         back = f"STATES:{path}\n"
         dummy_switch.pico.write(back.encode())
-        set_path = SwitchNetwork._verify_switch(dummy_switch)
+        set_path = SwitchNetwork.check_switch(dummy_switch)
         assert set_path == path
     # send no path
     dummy_switch.pico.write(b"")
     with pytest.raises(TimeoutError):
-        SwitchNetwork._verify_switch(dummy_switch)
+        SwitchNetwork.check_switch(dummy_switch)
     # send a path without STATES:
     dummy_switch.pico.write(b"0" * len(dummy_switch.setpins) + b"\n")
     with pytest.raises(ValueError):
-        SwitchNetwork._verify_switch(dummy_switch)
+        SwitchNetwork.check_switch(dummy_switch)
 
 
 def test_powerdown(dummy_switch):
@@ -70,5 +73,6 @@ def test_powerdown(dummy_switch):
     # with verify
     for pin in dummy_switch.setpins:
         pin.value(1)
-    path = dummy_switch.powerdown(verify=True)
-    assert path == "0" * len(dummy_switch.setpins)
+    dummy_switch.powerdown(verify=True)
+    for pin in dummy_switch.setpins:
+        assert pin.value() == 0

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -19,6 +19,7 @@ def test_init_failure():
     with pytest.raises(ValueError):
         SwitchNetwork(paths=paths)
 
+
 def test_make_serial_failure(monkeypatch):
     def fake_serial(port, baudrate, timeout=None):
         raise serial.SerialException("Cannot open serial port")
@@ -26,6 +27,7 @@ def test_make_serial_failure(monkeypatch):
     monkeypatch.setattr(serial, "Serial", fake_serial)
     with pytest.raises(RuntimeError):
         SwitchNetwork()  # can't open serial port
+
 
 def test_init(dummy_switch):
     # test with default settings
@@ -39,6 +41,7 @@ def test_init(dummy_switch):
     paths = {"test_path1": path1, "test_path2": path2}
     custom_switch = switch_network.testing.DummySwitchNetwork(paths=paths)
     assert custom_switch.paths == paths
+
 
 def test_switch(dummy_switch, mocker):
     # spy on check_switch

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -55,6 +55,7 @@ def test_switch(dummy_switch, mocker):
         nread = len(path) + 2
         read = dummy_switch.pico.readline(nread).strip().decode()
         assert read == path
+    spy.reset_mock()  # reset spy for next test
     # verify switch states
     for pathname in dummy_switch.paths:
         path = dummy_switch.paths[pathname]


### PR DESCRIPTION
This is cleaner and more explicit error handling than returning the switch state and useful in VNA code.