### PR TITLE
Add C implementation for Pico switch network

### DIFF
--- a/pico_c/CMakeLists.txt
+++ b/pico_c/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.13)
+
+# Pull in SDK (must be before project)
+include(pico_sdk_import.cmake)
+
+project(switch_network C CXX ASM)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+# Initialize the SDK
+pico_sdk_init()
+
+add_executable(switch_network
+    src/main.c
+)
+
+# Pull in common dependencies
+target_link_libraries(switch_network
+    pico_stdlib
+)
+
+# Enable USB output, disable UART output
+pico_enable_stdio_usb(switch_network 1)
+pico_enable_stdio_uart(switch_network 0)
+
+# Create map/bin/hex/uf2 file etc.
+pico_add_extra_outputs(switch_network)

--- a/pico_c/README.md
+++ b/pico_c/README.md
@@ -1,0 +1,65 @@
+# Raspberry Pi Pico C Implementation
+
+This directory contains the C implementation of the switch network functionality for the Raspberry Pi Pico, replacing the MicroPython version.
+
+## Features
+
+- Reads commands from USB serial (stdio)
+- Controls 8 GPIO pins based on received commands
+- Support for verification commands (commands ending with '!')
+- Compatible with the existing Python switch network interface
+
+## GPIO Pin Configuration
+
+The following GPIO pins are used for switches:
+- GPIO 6, 5, 11, 3, 15, 0, 8, 16
+
+## Building
+
+### Prerequisites
+
+1. Install the Raspberry Pi Pico SDK
+2. Set the `PICO_SDK_PATH` environment variable:
+   ```bash
+   export PICO_SDK_PATH=/path/to/pico-sdk
+   ```
+
+### Build Process
+
+Run the build script:
+```bash
+./build.sh
+```
+
+Or manually:
+```bash
+mkdir build
+cd build
+cmake ..
+make -j$(nproc)
+```
+
+## Flashing to Pico
+
+1. Hold the BOOTSEL button while connecting the Pico to USB
+2. Copy `build/switch_network.uf2` to the RPI-RP2 drive that appears
+3. The Pico will automatically reboot with the new firmware
+
+## Command Protocol
+
+The C implementation maintains the same protocol as the MicroPython version:
+
+### Basic Commands
+- Send a string of 8 characters (0s and 1s) followed by newline
+- Example: `10110000\n` sets the corresponding GPIO pins
+
+### Verification Commands
+- Append '!' to request verification: `10110000!\n`
+- Pico responds with `STATES:xxxxxxxx\n` showing current pin states
+
+## Differences from MicroPython Version
+
+- Uses USB CDC for serial communication instead of UART
+- Slightly faster response times
+- Lower memory usage
+- No runtime Python interpreter overhead

--- a/pico_c/build.sh
+++ b/pico_c/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Build script for Pico C switch network
+
+# Check if PICO_SDK_PATH is set
+if [ -z "$PICO_SDK_PATH" ]; then
+    echo "Error: PICO_SDK_PATH environment variable is not set"
+    echo "Please set it to the location of your Pico SDK installation"
+    echo "Example: export PICO_SDK_PATH=/path/to/pico-sdk"
+    exit 1
+fi
+
+# Create build directory
+mkdir -p build
+cd build
+
+# Run cmake
+cmake ..
+
+# Build the project
+make -j$(nproc)
+
+echo "Build complete! The UF2 file is located at: build/switch_network.uf2"
+echo "To flash to Pico:"
+echo "1. Hold BOOTSEL button while connecting Pico to USB"
+echo "2. Copy build/switch_network.uf2 to the RPI-RP2 drive"

--- a/pico_c/pico_sdk_import.cmake
+++ b/pico_c/pico_sdk_import.cmake
@@ -1,0 +1,62 @@
+# This is a copy of <PICO_SDK_PATH>/external/pico_sdk_import.cmake
+
+# This can be dropped into an external project to help locate this SDK
+# It should be include()ed prior to project()
+
+if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
+    set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
+    message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT} AND (NOT PICO_SDK_FETCH_FROM_GIT))
+    set(PICO_SDK_FETCH_FROM_GIT $ENV{PICO_SDK_FETCH_FROM_GIT})
+    message("Using PICO_SDK_FETCH_FROM_GIT from environment ('${PICO_SDK_FETCH_FROM_GIT}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_PATH} AND (NOT PICO_SDK_FETCH_FROM_GIT_PATH))
+    set(PICO_SDK_FETCH_FROM_GIT_PATH $ENV{PICO_SDK_FETCH_FROM_GIT_PATH})
+    message("Using PICO_SDK_FETCH_FROM_GIT_PATH from environment ('${PICO_SDK_FETCH_FROM_GIT_PATH}')")
+endif ()
+
+set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the Raspberry Pi Pico SDK")
+set(PICO_SDK_FETCH_FROM_GIT "${PICO_SDK_FETCH_FROM_GIT}" CACHE BOOL "Set to ON to fetch copy of SDK from git if not otherwise locatable")
+set(PICO_SDK_FETCH_FROM_GIT_PATH "${PICO_SDK_FETCH_FROM_GIT_PATH}" CACHE FILEPATH "location to download SDK")
+
+if (NOT PICO_SDK_PATH)
+    if (PICO_SDK_FETCH_FROM_GIT)
+        include(FetchContent)
+        set(FETCHCONTENT_BASE_DIR_SAVE ${FETCHCONTENT_BASE_DIR})
+        if (PICO_SDK_FETCH_FROM_GIT_PATH)
+            get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
+        endif ()
+        FetchContent_Declare(
+                pico_sdk
+                GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                GIT_TAG master
+        )
+        if (NOT pico_sdk)
+            message("Downloading Raspberry Pi Pico SDK")
+            FetchContent_Populate(pico_sdk)
+            set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
+        endif ()
+        set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
+    else ()
+        message(FATAL_ERROR
+                "SDK location was not specified. Please set PICO_SDK_PATH or set PICO_SDK_FETCH_FROM_GIT to on to fetch from git."
+                )
+    endif ()
+endif ()
+
+get_filename_component(PICO_SDK_PATH "${PICO_SDK_PATH}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+if (NOT EXISTS ${PICO_SDK_PATH})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' not found")
+endif ()
+
+set(PICO_SDK_INIT_CMAKE_FILE ${PICO_SDK_PATH}/pico_sdk_init.cmake)
+if (NOT EXISTS ${PICO_SDK_INIT_CMAKE_FILE})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' does not appear to contain the Raspberry Pi Pico SDK")
+endif ()
+
+set(PICO_SDK_PATH ${PICO_SDK_PATH} CACHE PATH "Path to the Raspberry Pi Pico SDK" FORCE)
+
+include(${PICO_SDK_INIT_CMAKE_FILE})

--- a/pico_c/src/main.c
+++ b/pico_c/src/main.c
@@ -1,0 +1,80 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "pico/stdlib.h"
+
+// GPIO pins for switches
+const uint GPIOS[] = {6, 5, 11, 3, 15, 0, 8, 16};
+const uint NUM_GPIOS = sizeof(GPIOS) / sizeof(GPIOS[0]);
+
+// Maximum command length: NUM_GPIOS + '!' + '\n' + '\0'
+#define MAX_COMMAND_LEN (NUM_GPIOS + 3)
+
+void set_switch_states(const char* statestr) {
+    size_t len = strlen(statestr);
+    bool verify = false;
+    
+    // Check if verification is requested
+    if (len > 0 && statestr[len - 1] == '!') {
+        verify = true;
+        len--;  // Remove the '!' from length
+    }
+    
+    // Check if command length matches number of pins
+    if (len != NUM_GPIOS) {
+        return;
+    }
+    
+    // Set each GPIO pin state
+    for (uint i = 0; i < NUM_GPIOS && i < len; i++) {
+        if (statestr[i] == '0') {
+            gpio_put(GPIOS[i], 0);
+        } else if (statestr[i] == '1') {
+            gpio_put(GPIOS[i], 1);
+        } else {
+            // Invalid character, abort
+            return;
+        }
+    }
+    
+    // If verification requested, send back current states
+    if (verify) {
+        printf("STATES:");
+        for (uint i = 0; i < NUM_GPIOS; i++) {
+            printf("%d", gpio_get(GPIOS[i]) ? 1 : 0);
+        }
+        printf("\n");
+    }
+}
+
+int main() {
+    // Initialize stdio
+    stdio_init_all();
+    
+    // Initialize GPIO pins as outputs
+    for (uint i = 0; i < NUM_GPIOS; i++) {
+        gpio_init(GPIOS[i]);
+        gpio_set_dir(GPIOS[i], GPIO_OUT);
+        gpio_put(GPIOS[i], 0);  // Set all pins to low initially
+    }
+    
+    char command[MAX_COMMAND_LEN];
+    
+    // Main loop
+    while (true) {
+        // Read command from stdin
+        int ch;
+        uint pos = 0;
+        
+        while ((ch = getchar()) != '\n' && ch != EOF && pos < MAX_COMMAND_LEN - 1) {
+            command[pos++] = (char)ch;
+        }
+        
+        if (pos > 0) {
+            command[pos] = '\0';  // Null terminate
+            set_switch_states(command);
+        }
+    }
+    
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Added native C implementation to replace MicroPython version on Pico
- Maintains full protocol compatibility with existing Python `SwitchNetwork` class
- Includes complete build system with CMake and documentation

## Key Features
- **Performance**: Lower latency and memory usage compared to MicroPython
- **Compatibility**: Same GPIO pins and command protocol
- **USB CDC**: Direct USB serial communication
- **Build system**: CMake configuration with automated build script

## Files Added
- `pico_c/src/main.c` - Core C implementation
- `pico_c/CMakeLists.txt` - CMake build configuration
- `pico_c/build.sh` - Build automation script
- `pico_c/README.md` - Documentation and usage instructions

## Test Plan
- [ ] Build C firmware with Pico SDK
- [ ] Flash to Pico and verify GPIO control
- [ ] Test with existing Python `SwitchNetwork` class
- [ ] Verify verification commands work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)